### PR TITLE
fix: add cache TTL and polling fallback for reliable session updates

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -127,11 +127,35 @@ export function createServer(options: ServerOptions) {
         });
 
         while (isConnected) {
+          await stream.sleep(5000);
+          if (!isConnected) break;
+
+          // Periodic poll to catch changes the watcher may have missed
+          try {
+            const current = await getSessions();
+            const newOrUpdated = current.filter((s) => {
+              const known = knownSessions.get(s.id);
+              return known === undefined || known !== s.timestamp;
+            });
+
+            for (const s of current) {
+              knownSessions.set(s.id, s.timestamp);
+            }
+
+            if (newOrUpdated.length > 0) {
+              await stream.writeSSE({
+                event: "sessionsUpdate",
+                data: JSON.stringify(newOrUpdated),
+              });
+            }
+          } catch {
+            // Ignore poll errors
+          }
+
           await stream.writeSSE({
             event: "heartbeat",
             data: JSON.stringify({ timestamp: Date.now() }),
           });
-          await stream.sleep(30000);
         }
       } catch {
         // Connection closed
@@ -197,11 +221,24 @@ export function createServer(options: ServerOptions) {
         });
 
         while (isConnected) {
+          await stream.sleep(5000);
+          if (!isConnected) break;
+
+          // Periodic poll for new messages in case watcher missed events
+          const { messages: newMessages, nextOffset: newOffset } =
+            await getConversationStream(sessionId, offset);
+          if (newMessages.length > 0) {
+            offset = newOffset;
+            await stream.writeSSE({
+              event: "messages",
+              data: JSON.stringify(newMessages),
+            });
+          }
+
           await stream.writeSSE({
             event: "heartbeat",
             data: JSON.stringify({ timestamp: Date.now() }),
           });
-          await stream.sleep(30000);
         }
       } catch {
         // Connection closed

--- a/api/storage.ts
+++ b/api/storage.ts
@@ -61,6 +61,8 @@ let claudeDir = join(homedir(), ".claude");
 let projectsDir = join(claudeDir, "projects");
 const fileIndex = new Map<string, string>();
 let historyCache: HistoryEntry[] | null = null;
+let historyCacheTime = 0;
+const HISTORY_CACHE_TTL_MS = 5000;
 const pendingRequests = new Map<string, Promise<unknown>>();
 
 export function initStorage(dir?: string): void {
@@ -74,6 +76,7 @@ export function getClaudeDir(): string {
 
 export function invalidateHistoryCache(): void {
   historyCache = null;
+  historyCacheTime = 0;
 }
 
 export function addToFileIndex(sessionId: string, filePath: string): void {
@@ -131,9 +134,11 @@ async function loadHistoryCache(): Promise<HistoryEntry[]> {
     }
 
     historyCache = entries;
+    historyCacheTime = Date.now();
     return entries;
   } catch {
     historyCache = [];
+    historyCacheTime = Date.now();
     return [];
   }
 }
@@ -232,9 +237,13 @@ export async function loadStorage(): Promise<void> {
   await Promise.all([buildFileIndex(), loadHistoryCache()]);
 }
 
+function isHistoryCacheStale(): boolean {
+  return !historyCache || (Date.now() - historyCacheTime > HISTORY_CACHE_TTL_MS);
+}
+
 export async function getSessions(): Promise<Session[]> {
   return dedupe("getSessions", async () => {
-    const entries = historyCache ?? (await loadHistoryCache());
+    const entries = isHistoryCacheStale() ? await loadHistoryCache() : historyCache!;
     const sessions: Session[] = [];
     const seenIds = new Set<string>();
 
@@ -264,7 +273,7 @@ export async function getSessions(): Promise<Session[]> {
 }
 
 export async function getProjects(): Promise<string[]> {
-  const entries = historyCache ?? (await loadHistoryCache());
+  const entries = isHistoryCacheStale() ? await loadHistoryCache() : historyCache!;
   const projects = new Set<string>();
 
   for (const entry of entries) {


### PR DESCRIPTION
historyCache had no expiry — once loaded at server start it stayed forever unless chokidar fired invalidateHistoryCache(). In environments where inotify is unreliable (Linux containers, bind mounts, VMs), the cache became permanently stale and new sessions never appeared in the UI.

- Add 5s TTL to history cache so it self-refreshes
- Add 5s SSE polling for sessions and conversation streams as fallback when file watcher misses events